### PR TITLE
Fix Compliance Test Failures for BMP581

### DIFF
--- a/tests/drivers/build_all/sensor/i2c.dtsi
+++ b/tests/drivers/build_all/sensor/i2c.dtsi
@@ -552,12 +552,6 @@ test_i2c_bmp388: bmp388@55 {
 	int-gpios = <&test_gpio 0 0>;
 };
 
-test_i2c_bmp581: bmp581@46 {
-	compatible = "bosch,bmp581";
-	reg = <0x46>;
-	int-gpios = <&test_gpio 0 0>;
-};
-
 test_i2c_lm75: lm75@56 {
 	compatible = "lm75";
 	reg = <0x56>;
@@ -749,4 +743,10 @@ test_i2c_ist8310@6f {
 	compatible = "isentek,ist8310";
 	reg = <0x6f>;
 	status = "okay";
+};
+
+test_i2c_bmp581: bmp581@70 {
+	compatible = "bosch,bmp581";
+	reg = <0x70>;
+	int-gpios = <&test_gpio 0 0>;
 };


### PR DESCRIPTION
Hello @MeisterBob,

I see that in the pull request you created in zephyr project. It was failing in compliance tests due to author email mismatch. I have amended my commits to fix this issue. You will see the amended commits here. I have also realized that it is failing again due to no body content in some of your commits, do you want to amend those? Or should I take the freedom to squash your commits to the first commit? 

And I have updated the i2c.dtsi to fix the duplicated id issue for bmp581 do you see any issues with it?